### PR TITLE
docs: remove experimental label and update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Tekton task catalog for the Conforma (Enterprise Contract) team. Provides reusable verification tasks consumed as Tekton Bundles. Tasks are primarily synced from the [ec-cli](https://github.com/conforma/cli/) repository.
-
-**Status:** Experimental — tasks are produced and bundled by the ec-cli repo; this catalog tracks and publishes them.
+Tekton task catalog for the Conforma (Enterprise Contract) team. Provides reusable verification tasks consumed as Tekton Bundles in Konflux release pipelines. Tasks are synced from the [conforma/cli](https://github.com/conforma/cli/) repository and referenced by the [release-service-catalog](https://github.com/konflux-ci/release-service-catalog).
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # tekton-catalog
 
-[Experimental] All the Tekton tasks provided by the Conforma team.
+Tekton tasks provided by the Conforma team.
 
-This is an experimental repository. At this moment, the tasks should be consumed as Tekton
-Bundles which are produced by [ec](https://github.com/conforma/cli/) repository.
+This repository contains the source for Tekton verification tasks used in
+[Konflux](https://github.com/konflux-ci) release pipelines. Tasks are synced
+from the [conforma/cli](https://github.com/conforma/cli/) repository and
+consumed as Tekton Bundles via the
+[release-service-catalog](https://github.com/konflux-ci/release-service-catalog).
+
+## Syncing tasks from conforma/cli
+
+Task definitions originate in the [conforma/cli](https://github.com/conforma/cli/)
+repository. To sync them into this catalog:
+
+```bash
+hack/sync-ec-cli-tasks.sh <PATH_TO_EC_CLI_REPO>
+```


### PR DESCRIPTION
## Summary
- Remove "Experimental" label from README and CLAUDE.md
- Update README to explain the repo's role in Konflux release pipelines
- Add section on syncing tasks from conforma/cli

The tekton-catalog is now used in production by the [release-service-catalog](https://github.com/konflux-ci/release-service-catalog) and should no longer be described as experimental.

https://redhat.atlassian.net/browse/EC-1934