### PR TITLE
Skip release branches that don't exist in tekton-catalog

### DIFF
--- a/hack/sync-ec-cli-tasks.sh
+++ b/hack/sync-ec-cli-tasks.sh
@@ -103,10 +103,10 @@ popd > /dev/null
 
 for branch in ${ec_cli_branches[@]}; do
     if ! echo "$tekton_catalog_branches" | grep -Fxq "$branch"; then
-      add_definitions "${branch}" "origin/main"
-    else
-      add_definitions "${branch}" "origin/${branch}"
+      echo "Skipping ${branch} - no matching branch in tekton-catalog"
+      continue
     fi
+    add_definitions "${branch}" "origin/${branch}"
 done
 
 add_definitions "main" "origin/main"


### PR DESCRIPTION
Previously, when a release branch existed in conforma/cli but not in tekton-catalog, the script would sync its definitions into main. This created incorrect PRs mixing release definitions into main. Now the script simply skips those branches.